### PR TITLE
multi-target package

### DIFF
--- a/FsGrpc.Tools/FsGrpc.Tools.csproj
+++ b/FsGrpc.Tools/FsGrpc.Tools.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyName>Protobuf.MSBuild</AssemblyName>
     <VersionPrefix>$(FSGRPCTOOLS_VERSION)$(VersionSuffix)</VersionPrefix>
-    <!-- If changing targets, change also paths in Google.Protobuf.Tools.targets. -->
+    <!-- If changing target frameworks, ensure that all corresponding framework paths are updated in Google.Protobuf.Tools.targets, as the targets file dynamically selects between assemblies for each framework. -->
     <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/FsGrpc.Tools/FsGrpc.Tools.csproj
+++ b/FsGrpc.Tools/FsGrpc.Tools.csproj
@@ -3,7 +3,7 @@
     <AssemblyName>Protobuf.MSBuild</AssemblyName>
     <VersionPrefix>$(FSGRPCTOOLS_VERSION)$(VersionSuffix)</VersionPrefix>
     <!-- If changing targets, change also paths in Google.Protobuf.Tools.targets. -->
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
@@ -70,18 +70,25 @@
     <None Include="@(_Asset)" Pack="true" Visible="false" />
   </ItemGroup>
 
+  <!-- Common task-related packages across TFMs -->
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Framework; Microsoft.Build.Utilities.Core" Version="17.9.*" PrivateAssets="all" ExcludeAssets="Runtime" />
     <PackageReference Include="MedallionTopologicalSort" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="FsGrpc.ProtocGenFsGrpc" Version="0.6.2" PrivateAssets="All" />
+  </ItemGroup>
 
+  <!-- Packages only compatible with net8.0 -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="fsgrpc" Version="1.1.0" />
     <PackageReference Include="Focal.Core" Version="0.10.0" />
     <PackageReference Include="Grpc.AspNetCore.Server.ClientFactory" Version="2.62.0" />
+  </ItemGroup>
 
-    <None Include="$(OutputPath)\$(AssemblyName).deps.json" Pack="true" PackagePath="build\_protobuf\net6.0" Visible="false" />
-    <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="build\_protobuf\net6.0" Visible="false" />
-    <None Include="$(NugetPackageRoot)\medalliontopologicalsort\1.0.0\lib\netstandard2.0\MedallionTopologicalSort.dll" Pack="true" PackagePath="build\_protobuf\net6.0" Visible="false" />
+  <ItemGroup>
+    <!-- Place built task assemblies under both TFMs for multi-targeting -->
+    <None Include="$(OutputPath)\$(AssemblyName).deps.json" Pack="true" PackagePath="build\_protobuf\$(TargetFramework)" Visible="false" />
+    <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="build\_protobuf\$(TargetFramework)" Visible="false" />
+    <None Include="$(NugetPackageRoot)\medalliontopologicalsort\1.0.0\lib\netstandard2.0\MedallionTopologicalSort.dll" Pack="true" PackagePath="build\_protobuf\$(TargetFramework)" Visible="false" />
     <None Include="$(NugetPackageRoot)\fsgrpc.protocgenfsgrpc\0.6.2\tools\**\*" Pack="true" PackagePath="tools\" Visible="false" />
   </ItemGroup>
 </Project>

--- a/FsGrpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
+++ b/FsGrpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
@@ -7,8 +7,8 @@
     <!-- Configuration is passing the smoke test. -->
     <Protobuf_ProjectSupported Condition=" '$(Protobuf_Generator)' != '' ">true</Protobuf_ProjectSupported>
     <!-- Allow assembly file to be specified externally for testing by setting property _Protobuf_MsBuildAssembly -->
-    <_Protobuf_MsBuildAssembly Condition=" '$(_Protobuf_MsBuildAssembly)' == '' and Exists('net8.0\Protobuf.MSBuild.dll') ">net8.0\Protobuf.MSBuild.dll</_Protobuf_MsBuildAssembly>
-    <_Protobuf_MsBuildAssembly Condition=" '$(_Protobuf_MsBuildAssembly)' == '' and Exists('net6.0\Protobuf.MSBuild.dll') ">net6.0\Protobuf.MSBuild.dll</_Protobuf_MsBuildAssembly>
+    <_Protobuf_MsBuildAssembly Condition=" '$(_Protobuf_MsBuildAssembly)' == '' and Exists('$(MSBuildThisFileDirectory)net8.0\Protobuf.MSBuild.dll') ">$(MSBuildThisFileDirectory)net8.0\Protobuf.MSBuild.dll</_Protobuf_MsBuildAssembly>
+    <_Protobuf_MsBuildAssembly Condition=" '$(_Protobuf_MsBuildAssembly)' == '' and Exists('$(MSBuildThisFileDirectory)net6.0\Protobuf.MSBuild.dll') ">$(MSBuildThisFileDirectory)net6.0\Protobuf.MSBuild.dll</_Protobuf_MsBuildAssembly>
   </PropertyGroup>
 
   <UsingTask AssemblyFile="$(_Protobuf_MsBuildAssembly)" TaskName="Grpc.Tools.ProtoToolsPlatform" />

--- a/FsGrpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
+++ b/FsGrpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
@@ -7,7 +7,8 @@
     <!-- Configuration is passing the smoke test. -->
     <Protobuf_ProjectSupported Condition=" '$(Protobuf_Generator)' != '' ">true</Protobuf_ProjectSupported>
     <!-- Allow assembly file to be specified externally for testing by setting property _Protobuf_MsBuildAssembly -->
-    <_Protobuf_MsBuildAssembly Condition=" '$(_Protobuf_MsBuildAssembly)' == '' and '$(MSBuildRuntimeType)' == 'Core' ">net6.0\Protobuf.MSBuild.dll</_Protobuf_MsBuildAssembly>
+    <_Protobuf_MsBuildAssembly Condition=" '$(_Protobuf_MsBuildAssembly)' == '' and Exists('net8.0\Protobuf.MSBuild.dll') ">net8.0\Protobuf.MSBuild.dll</_Protobuf_MsBuildAssembly>
+    <_Protobuf_MsBuildAssembly Condition=" '$(_Protobuf_MsBuildAssembly)' == '' and Exists('net6.0\Protobuf.MSBuild.dll') ">net6.0\Protobuf.MSBuild.dll</_Protobuf_MsBuildAssembly>
   </PropertyGroup>
 
   <UsingTask AssemblyFile="$(_Protobuf_MsBuildAssembly)" TaskName="Grpc.Tools.ProtoToolsPlatform" />


### PR DESCRIPTION
This pull request updates the `FsGrpc.Tools` project to support both .NET 6.0 and .NET 8.0, improving compatibility and packaging for users on different target frameworks. The changes also refine how dependencies and build outputs are handled for multi-targeting.

**Multi-targeting and Packaging Improvements:**

* Updated `FsGrpc.Tools.csproj` to target both `net6.0` and `net8.0` by changing the `TargetFramework` property to `TargetFrameworks`, enabling multi-targeted builds.
* Refactored package references so that common dependencies are included for all target frameworks, while certain packages are only included when building for `net8.0`.
* Adjusted packaging of output assemblies and dependencies to ensure that build artifacts are placed under the correct framework-specific directories for both `net6.0` and `net8.0`.

**Build Logic Enhancements:**

* Updated `Google.Protobuf.Tools.targets` to prefer loading the `net8.0` version of `Protobuf.MSBuild.dll` if available, falling back to `net6.0` as needed, improving runtime compatibility and flexibility.